### PR TITLE
Install Git Updater when running tests.

### DIFF
--- a/.github/workflows/wp-phpunit.yml
+++ b/.github/workflows/wp-phpunit.yml
@@ -13,7 +13,7 @@ on:
       ##- main
   pull_request:
     branches:
-      ##- develop
+      - develop
       - master
       ##- main
 

--- a/bin/install-wp-tests.sh
+++ b/bin/install-wp-tests.sh
@@ -115,6 +115,17 @@ install_db() {
 	mysqladmin create $DB_NAME --user="$DB_USER" --password="$DB_PASS"$EXTRA
 }
 
+install_gu() {
+	if [ -d "${WP_CORE_DIR}wp-content/plugins/git-updater" ]; then
+		return;
+	fi
+
+	local LATEST_GU_ZIP=$(curl -s https://api.github.com/repos/afragen/git-updater/releases/latest | grep browser_download_url | cut -d '"' -f 4)
+	curl -L $LATEST_GU_ZIP > ${WP_CORE_DIR}wp-content/plugins/git-updater.zip
+	unzip -q ${WP_CORE_DIR}wp-content/plugins/git-updater.zip -d ${WP_CORE_DIR}wp-content/plugins
+}
+
 install_wp
 install_test_suite
 install_db
+install_gu

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -21,6 +21,15 @@ if ( ! file_exists( $_tests_dir . '/includes/functions.php' ) ) {
 require_once $_tests_dir . '/includes/functions.php';
 
 /**
+ * Manually load dependencies.
+ */
+function _manually_load_dependencies() {
+	echo 'Loading Git Updater...' . PHP_EOL;
+	require WP_PLUGIN_DIR . '/git-updater/git-updater.php';
+}
+tests_add_filter( 'muplugins_loaded', '_manually_load_dependencies' );
+
+/**
  * Manually load the plugin being tested.
  */
 function _manually_load_plugin() {


### PR DESCRIPTION
Git Updater is required to run tests. This installs the latest version of Git Updater, and loads it when bootstrapping the tests.

**Note:** This PR also modifies the workflow file to make it run for PRs so its changes can be seen pre-merge. However, running the workflow on PRs is a good thing long-term.

Fixes #3